### PR TITLE
[IMP] mis_builder. Add 'Display details before KPI' field to KPI's.

### DIFF
--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -409,11 +409,15 @@ class KpiMatrix(object):
         yields KpiMatrixRow.
         """
         for kpi_row in self._kpi_rows.values():
-            yield kpi_row
+            if not kpi_row.kpi.auto_expand_accounts_before_kpi:
+                yield kpi_row
             detail_rows = self._detail_rows[kpi_row.kpi].values()
             detail_rows = sorted(detail_rows, key=lambda r: r.description)
             for detail_row in detail_rows:
                 yield detail_row
+            if kpi_row.kpi.auto_expand_accounts_before_kpi:
+                yield kpi_row
+
 
     def iter_cols(self):
         """ Iterate columns in display order.
@@ -548,6 +552,7 @@ class MisReportKpi(models.Model):
         copy=True,
     )
     auto_expand_accounts = fields.Boolean(string='Display details by account')
+    auto_expand_accounts_before_kpi = fields.Boolean(string='Display details before KPI')
     auto_expand_accounts_style_id = fields.Many2one(
         string="Style for account detail rows",
         comodel_name="mis.report.style",

--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -125,6 +125,8 @@
                         <field name="auto_expand_accounts"/>
                         <field name="auto_expand_accounts_style_id"
                                attrs="{'invisible': [('auto_expand_accounts', '!=', True)]}"/>
+                        <field name="auto_expand_accounts_before_kpi"
+                               attrs="{'invisible': [('auto_expand_accounts', '!=', True)]}"/>
                     </group>
                     <group col="2" string="Legend (for kpi expressions)">
                         <group>


### PR DESCRIPTION
Setting 'Display details before KPI' displays account detail rows before the
main KPI row.