### PR TITLE
[IMP] mis_builder. Add 'Display KPI row' field to KPI's.

### DIFF
--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -30,6 +30,10 @@ from .mis_kpi_data import (
 
 _logger = logging.getLogger(__name__)
 
+KPOS_ABOVE = 'above'
+KPOS_BELOW = 'below'
+KPOS_NONE = 'none'
+
 
 class AutoStruct(object):
 
@@ -409,15 +413,22 @@ class KpiMatrix(object):
         yields KpiMatrixRow.
         """
         for kpi_row in self._kpi_rows.values():
-            if not kpi_row.kpi.auto_expand_accounts_before_kpi:
+            above = \
+                (not kpi_row.kpi.auto_expand_accounts) or \
+                (kpi_row.kpi.auto_expand_accounts_kpi_position in (KPOS_ABOVE,
+                                                                   False))
+            below = \
+                kpi_row.kpi.auto_expand_accounts and \
+                (kpi_row.kpi.auto_expand_accounts_kpi_position == KPOS_BELOW)
+
+            if above:
                 yield kpi_row
             detail_rows = self._detail_rows[kpi_row.kpi].values()
             detail_rows = sorted(detail_rows, key=lambda r: r.description)
             for detail_row in detail_rows:
                 yield detail_row
-            if kpi_row.kpi.auto_expand_accounts_before_kpi:
+            if below:
                 yield kpi_row
-
 
     def iter_cols(self):
         """ Iterate columns in display order.
@@ -552,7 +563,13 @@ class MisReportKpi(models.Model):
         copy=True,
     )
     auto_expand_accounts = fields.Boolean(string='Display details by account')
-    auto_expand_accounts_before_kpi = fields.Boolean(string='Display details before KPI')
+    auto_expand_accounts_kpi_position = fields.Selection(
+        [(KPOS_ABOVE, _('Above account details')),
+         (KPOS_BELOW, _('Below account details')),
+         (KPOS_NONE, _('Hide KPI row')),
+        ],
+        string='Display KPI row',
+        default=KPOS_ABOVE)
     auto_expand_accounts_style_id = fields.Many2one(
         string="Style for account detail rows",
         comodel_name="mis.report.style",

--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -125,8 +125,9 @@
                         <field name="auto_expand_accounts"/>
                         <field name="auto_expand_accounts_style_id"
                                attrs="{'invisible': [('auto_expand_accounts', '!=', True)]}"/>
-                        <field name="auto_expand_accounts_before_kpi"
-                               attrs="{'invisible': [('auto_expand_accounts', '!=', True)]}"/>
+                        <field name="auto_expand_accounts_kpi_position"
+                               attrs="{'invisible': [('auto_expand_accounts', '!=', True)],
+                                       'required': [('auto_expand_accounts', '=', True)],}"/>
                     </group>
                     <group col="2" string="Legend (for kpi expressions)">
                         <group>


### PR DESCRIPTION
Allows KPI row to be positioned before or after account detail rows
or hidden entirely.

This replaces 'Display details before KPI' added in earlier commit.